### PR TITLE
fix(text-editor): type a/c/x/v as text when no modifier is held

### DIFF
--- a/web/text-editor.js
+++ b/web/text-editor.js
@@ -179,16 +179,24 @@ export class TextEditor {
           event.preventDefault();
           this.cursorPosition = 0;
           this.selectionAnchor = chars.length;
+        } else if (!this.composing) {
+          event.preventDefault();
+          insert(event.key);
         }
         break;
 
       case 'c':
       case 'x':
-        if (metaOrCtrl && hasSelection) {
+        if (metaOrCtrl) {
+          if (hasSelection) {
+            event.preventDefault();
+            const selected = chars.slice(selStart, selEnd).join('');
+            navigator.clipboard.writeText(selected).catch(() => {});
+            if (event.key === 'x') { insert(''); }
+          }
+        } else if (!this.composing) {
           event.preventDefault();
-          const selected = chars.slice(selStart, selEnd).join('');
-          navigator.clipboard.writeText(selected).catch(() => {});
-          if (event.key === 'x') { insert(''); }
+          insert(event.key);
         }
         break;
 
@@ -200,6 +208,9 @@ export class TextEditor {
               insert(text);
             }
           }).catch(() => {});
+        } else if (!this.composing) {
+          event.preventDefault();
+          insert(event.key);
         }
         break;
 


### PR DESCRIPTION
## Summary

- In the standalone demo's `TextEditor`, the switch on `event.key` matched `a`/`c`/`x`/`v` whether or not Cmd/Ctrl was pressed.
- The inner `metaOrCtrl` guard blocked the shortcut but didn't fall through to the default `insert(event.key)` path, so those letters silently dropped on the floor when typed plain.
- Each case now inserts the character when `metaOrCtrl` is false, mirroring the `default` branch. Cmd+A / Cmd+X / Cmd+C / Cmd+V still work as shortcuts.

## Test plan

- [ ] Open `web/index.html`, double-click to create text, type a sentence containing `a`, `c`, `x`, `v` — all letters appear.
- [ ] With text selected, Cmd+A still selects all.
- [ ] With selection, Cmd+X cuts, Cmd+C copies, Cmd+V pastes.
- [ ] IME composition still suppresses these inserts (`this.composing` guard preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)